### PR TITLE
Make `main` great again 

### DIFF
--- a/cli/action.yaml
+++ b/cli/action.yaml
@@ -2,9 +2,9 @@ name: 'Build FluCoMa Toolkit for CLI'
 description: 'Builds the FluCoMa Toolkit for Command-line Interface'
 inputs:
   branch:
-    description: 'Which branch to pull flucoma dependencies from (main/dev)'
+    description: 'Which branch to pull flucoma dependencies from (main/production)'
     required: true
-    default: 'dev'
+    default: 'main'
 runs:
   using: "composite"
   steps:

--- a/docs/action.yaml
+++ b/docs/action.yaml
@@ -2,9 +2,9 @@ name: 'Build FluCoMa Toolkit Docs for Max'
 description: 'Builds the FluCoMa Docs Toolkit for Max'
 inputs:
   branch:
-    description: 'Which branch to pull dependencies from (main/dev)'
+    description: 'Which branch to pull dependencies from (main/production)'
     required: false
-    default: 'dev'
+    default: 'main'
   target: 
     description: 'Which docs target to build'
     required: false 

--- a/env/action.yaml
+++ b/env/action.yaml
@@ -2,9 +2,9 @@ name: 'Setup FluCoMa Build Enivronment'
 description: 'Installs common tools across FluCoMa continuous integration deployment'
 inputs:
   branch:
-    description: 'Which branch to pull dependencies from (main/dev)'
+    description: 'Which branch to pull dependencies from (main/production)'
     required: false
-    default: 'dev'
+    default: 'main'
 
 runs:
   using: "composite"

--- a/max/action.yaml
+++ b/max/action.yaml
@@ -2,9 +2,9 @@ name: 'Build FluCoMa Toolkit for Max'
 description: 'Builds the FluCoMa Toolkit for Max'
 inputs:
   branch:
-    description: 'Which branch to pull flucoma dependencies from (main/dev)'
+    description: 'Which branch to pull flucoma dependencies from (main/production)'
     required: true
-    default: 'dev'
+    default: 'main'
 runs:
   using: "composite"
   steps:

--- a/pd/action.yaml
+++ b/pd/action.yaml
@@ -2,9 +2,9 @@ name: 'Build FluCoMa Toolkit for PureData'
 description: 'Builds the FluCoMa Toolkit for PureData'
 inputs:
   branch:
-    description: 'Which branch to pull flucoma dependencies from (main/dev)'
+    description: 'Which branch to pull flucoma dependencies from (main/production)'
     required: true
-    default: 'dev'
+    default: 'main'
 runs:
   using: "composite"
   steps:

--- a/sc/action.yaml
+++ b/sc/action.yaml
@@ -2,9 +2,9 @@ name: 'Build FluCoMa Toolkit for SuperCollider'
 description: 'Builds the FluCoMa Toolkit for SuperCollider'
 inputs:
   branch:
-    description: 'Which branch to pull flucoma dependencies from (main/dev)'
+    description: 'Which branch to pull flucoma dependencies from (main/production)'
     required: true
-    default: 'dev'
+    default: 'main'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Changes to CI infrastructure for moving to a `main` + `production` set up, where `main` is our day to day branch