### PR TITLE
Replace `set-output` with environment file

### DIFF
--- a/getversion/action.yaml
+++ b/getversion/action.yaml
@@ -9,6 +9,6 @@ runs:
   using: "composite"
   steps:
     - id: retrieve-version
-      run: echo "::set-output name=sha::$(cat flucoma.version.rc)"
+      run: echo "sha=$(cat flucoma.version.rc)" >> $GITHUB_OUTPUT
       working-directory: core
       shell: bash


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/