### PR TITLE
SC action: add input to select SC branch

### DIFF
--- a/sc/action.yaml
+++ b/sc/action.yaml
@@ -13,6 +13,10 @@ inputs:
     description: 'Select a specific branch for flucoma-core'
     required: false
     default: 'main'
+  sc_branch: 
+    description: 'Select an SC branch to use'
+    requireed: false 
+    default: 'main'
 runs:
   using: "composite"
   steps:
@@ -23,7 +27,7 @@ runs:
         python-version: '3.9'
             
     - name: Get SuperCollider Source
-      run: git clone --single-branch --branch main --recursive https://github.com/supercollider/supercollider.git sdk
+      run: git clone --single-branch --branch ${{ inputs.sc_branch }} --recursive https://github.com/supercollider/supercollider.git sdk
       shell: bash
 
     - name: Conditionally download flucoma-core 


### PR DESCRIPTION
Because of changes to SC in relation to our code crimes, we will need to be selective about which SC branch(es) we're releasing against, rather than just tugging on `main`. Furthermore, we might want to support dual releases during 3.13 to 3.14 transition (and again for 3.15). 