### PR TITLE
pass deken upload bool instead of action-side checks

### DIFF
--- a/deken/action.yaml
+++ b/deken/action.yaml
@@ -11,6 +11,9 @@ inputs:
   deken_password:
     description: 'Password from puredata.info credentials'
     required: true
+  upload:
+    description: 'Whether to upload to deken (true/false)'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -52,7 +55,7 @@ runs:
         echo '```' | tee -a $GITHUB_STEP_SUMMARY
 
     - name: Upload to deken
-      if: ${{ github.ref_name == 'production' || startsWith(github.ref_name, 'deken-') }}
+      if: ${{ inputs.upload == 'true' }}
       shell: bash
       run: |
         docker run --rm -e DEKEN_USERNAME="${{ inputs.deken_username }}" -e DEKEN_PASSWORD="${{ inputs.deken_password }}" \


### PR DESCRIPTION
this will make it easier to also handle nightly uploads. it also seems like the better design to not include this logic on the action side.

note that the [actions](https://github.com/flucoma/flucoma-pd/pull/118) for `flucoma-pd` still require a `v6` tag here. if that's not desired, we can also adapt the action calls and not pin them to a specific version.